### PR TITLE
AppIdentifier updated with `com.hiveauth.mobile`

### DIFF
--- a/src-capacitor/android/app/build.gradle
+++ b/src-capacitor/android/app/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
+apply plugin: 'com.google.gms.google-services'
 
 def keystoreProperties = new Properties()
 def keystorePropertiesFile = rootProject.file('signing.properties')
@@ -8,10 +9,10 @@ if (keystorePropertiesFile.exists()) {
 }
 
 android {
-  namespace "com.hiveauth.authsigner"
+  namespace "com.hiveauth.mobile"
   compileSdkVersion rootProject.ext.compileSdkVersion
   defaultConfig {
-    applicationId "com.hiveauth.authsigner"
+    applicationId "com.hiveauth.mobile"
     minSdkVersion rootProject.ext.minSdkVersion
     targetSdkVersion rootProject.ext.targetSdkVersion
     versionCode 12
@@ -66,6 +67,8 @@ dependencies {
 
   implementation 'androidx.webkit:webkit:1.7.0'
   implementation 'com.google.code.gson:gson:2.10.1'
+
+  implementation platform('com.google.firebase:firebase-bom:32.4.0')
 
   implementation project(':capacitor-android')
   testImplementation "junit:junit:$junitVersion"

--- a/src-capacitor/android/app/google-services.json
+++ b/src-capacitor/android/app/google-services.json
@@ -1,0 +1,68 @@
+{
+  "project_info": {
+    "project_number": "999426444559",
+    "project_id": "hive-auth-signer",
+    "storage_bucket": "hive-auth-signer.appspot.com"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:999426444559:android:6915eb485266a21aab427a",
+        "android_client_info": {
+          "package_name": "com.hiveauth.mobile"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "999426444559-vp3182sv9rvhd5lr3fl12ee9r13dqsp4.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyB5pJGwGlUWCNdOUTkuBI5EOlGJXLl2amY"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "999426444559-vp3182sv9rvhd5lr3fl12ee9r13dqsp4.apps.googleusercontent.com",
+              "client_type": 3
+            }
+          ]
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:999426444559:android:f253f8774a22dfbcab427a",
+        "android_client_info": {
+          "package_name": "com.hiveauth.mobile.debug"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "999426444559-vp3182sv9rvhd5lr3fl12ee9r13dqsp4.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyB5pJGwGlUWCNdOUTkuBI5EOlGJXLl2amY"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "999426444559-vp3182sv9rvhd5lr3fl12ee9r13dqsp4.apps.googleusercontent.com",
+              "client_type": 3
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/src-capacitor/android/app/src/main/java/com/hiveauth/mobile/HiveAuthSignerCustom.kt
+++ b/src-capacitor/android/app/src/main/java/com/hiveauth/mobile/HiveAuthSignerCustom.kt
@@ -1,4 +1,4 @@
-package com.hiveauth.authsigner
+package com.hiveauth.mobile
 
 import android.annotation.SuppressLint
 import android.net.Uri

--- a/src-capacitor/android/app/src/main/java/com/hiveauth/mobile/MainActivity.java
+++ b/src-capacitor/android/app/src/main/java/com/hiveauth/mobile/MainActivity.java
@@ -1,6 +1,5 @@
-package com.hiveauth.authsigner;
+package com.hiveauth.mobile;
 import android.content.Intent;
-import android.content.res.Configuration;
 import android.net.Uri;
 import android.os.Bundle;
 import com.getcapacitor.BridgeActivity;

--- a/src-capacitor/android/app/src/main/res/values/strings.xml
+++ b/src-capacitor/android/app/src/main/res/values/strings.xml
@@ -2,6 +2,6 @@
 <resources>
   <string name="app_name">HiveAuth</string>
   <string name="title_activity_main">HiveAuth</string>
-  <string name="package_name">com.hiveauth.authsigner</string>
-  <string name="custom_url_scheme">com.hiveauth.authsigner</string>
+  <string name="package_name">com.hiveauth.mobile</string>
+  <string name="custom_url_scheme">com.hiveauth.mobile</string>
 </resources>

--- a/src-capacitor/android/build.gradle
+++ b/src-capacitor/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:8.1.2'
-        classpath 'com.google.gms:google-services:4.3.15'
+        classpath 'com.google.gms:google-services:4.4.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
- Updated App-identifier with HiveAuth Mobile
- Instead of HiveAuth AuthSigner
- @VIM-Arcange You'll be required to delete old debug version of the app to avoid confusion
- If you don't delete, you may end up seeing 2 debug versions of the app.
